### PR TITLE
update composer dbal to v.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "illuminate/database": "^6.0|^7.30.4|^8.24.0",
         "illuminate/support": "^6.0|^7.3|^8.24.0",
-        "doctrine/dbal": "^2.10"
+        "doctrine/dbal": "^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.1|^6.0"


### PR DESCRIPTION
I get the following version conflict:

`    - naoray/eloquent-model-analyzer[v2.0.0, ..., v2.1.1] require doctrine/dbal ^2.10 -> found doctrine/dbal[v2.10.0, ..., 2.13.x-dev] but it conflicts with your root composer.json require (^3.0).`


PR to update the version of dbal